### PR TITLE
feat: Ask becomes fallback to tool permission system

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ graph TB
   "server_url": "http://localhost:8338",
 
   // Policy bundles to activate. Default: ["universal"]
-  "bundles": ["universal", "python", "git"],
-
-  // What to do when the server returns no decision: "allow", "ask", "deny". Default: "ask"
-  "default_policy_behavior": "ask"
+  "bundles": ["universal", "python", "git"]
 }
+```
+
+> **Note:** The `default_policy_behavior` setting is obsolete and no longer has any effect. When the
+> server has no policy opinion on a tool use, the client now defers to Claude Code's own native
+> permission system. You can configure `allowedTools` in your Claude Code settings to build up a
+> personal permission baseline that the policy layer will not override.

--- a/scripts/client.js
+++ b/scripts/client.js
@@ -67,7 +67,6 @@ async function main() {
   const config = loadConfig();
   const serverUrl = config.server_url || 'https://agent-policies.devleaps.nl';
   const bundles = config.bundles || ['universal'];
-  const defaultBehavior = config.default_policy_behavior || 'ask';
 
   let raw;
   try {
@@ -92,7 +91,7 @@ async function main() {
   }
 
   const endpoint = `/policy/claude-code/${hookEventName}`;
-  const body = { bundles, default_policy_behavior: defaultBehavior, event: payload };
+  const body = { bundles, event: payload };
 
   try {
     const { status, body: responseBody } = await post(serverUrl, endpoint, body);
@@ -104,6 +103,7 @@ async function main() {
     }
 
     process.stdout.write(responseBody);
+
     process.exit(0);
   } catch (e) {
     if (e.code === 'ECONNREFUSED') {


### PR DESCRIPTION
When no policy rule matches, the server now omits permissionDecision entirely so Claude Code or others fall back to their respective native permission system.