### PR TITLE
fix: remove hooks key from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   },
   "homepage": "https://github.com/Devleaps/agent-policies-claude-code",
   "repository": "https://github.com/Devleaps/agent-policies-claude-code",
-  "keywords": ["policies", "security", "hooks"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["policies", "security", "hooks"]
 }


### PR DESCRIPTION
## Summary
- Remove the `hooks` key from `.claude-plugin/plugin.json` to fix a hooks loading error

See https://github.com/affaan-m/everything-claude-code/issues/103#issuecomment-3815845743 . No need to specify the hooks dir at manifest as it's already hardcoded in claude code.

Fixes #3 