### PR TITLE
Send client home directory to policy server

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-policies-claude-code",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Forwards hook events to a policy server that can allow, deny, ask, or halt agent actions.",
   "author": {
     "name": "DevLeaps",

--- a/scripts/client.js
+++ b/scripts/client.js
@@ -94,6 +94,7 @@ async function main() {
   const body = {
     bundles,
     workspace_root: process.env.CLAUDE_PROJECT_DIR || null,
+    home: os.homedir(),
     event: payload,
   };
 


### PR DESCRIPTION
## Summary
- Sends `os.homedir()` as `home` in the request body alongside `workspace_root`.
- Enables the policy server to correctly resolve `~` paths against this client's actual home directory instead of the server's own $HOME (see companion server-side PR: Devleaps/agent-policies-server#59).

## Test plan
- [x] `node --check scripts/client.js` passes
- [ ] Verify a policy-server bash hook round-trip still succeeds end-to-end once the server-side PR is merged